### PR TITLE
Remove compile warnings

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -33,5 +33,5 @@ repositories {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
+    implementation 'com.facebook.react:react-native:+'
 }


### PR DESCRIPTION
'compile' is obsolete and has been replaced with 'implementation' and 'api' http://d.android.com/r/tools/update-dependency-configurations.html