### PR TITLE
Update android build.gradle settings.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -10,13 +10,17 @@ buildscript {
 
 apply plugin: 'com.android.library'
 
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion safeExtGet('compileSdkVersion', 23)
+    buildToolsVersion safeExtGet("buildToolsVersion", "23.0.1")
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 22
+        minSdkVersion safeExtGet('minSdkVersion', 16)
+        targetSdkVersion safeExtGet('targetSdkVersion', 22)
         versionCode 1
         versionName "1.0"
     }


### PR DESCRIPTION
Quite a few super popular RN packages (react-native-config, react-native-gesture-handler,  react-native-splash-screen, react-native-vector-icons, etc.) take the approach of using the root settings and then the local ones here as a fallback. This is working well for me locally.

Closes #5.

