### PR TITLE
Add canOverrideExistingModule() to support RN 0.60+

### DIFF
--- a/android/src/main/java/me/jhen/devsettings/DevSettingsModule.java
+++ b/android/src/main/java/me/jhen/devsettings/DevSettingsModule.java
@@ -106,4 +106,9 @@ public class DevSettingsModule extends ReactContextBaseJavaModule {
             }
         });
     }
+
+    @Override
+    public boolean canOverrideExistingModule() {
+      return false;
+    }
 }


### PR DESCRIPTION
This fixes an issue where React Native refuses to load citing

```
Native module DevSettings tried to override com.facebook.react.modules.debug.DevSettingsModule. Check that getPackages() method in MainApplication.java, it might be that module is being created twice. If this was your intention, set canOverrideExistingModule=true
```

It is the intention!